### PR TITLE
Feat: Authorized keys based login

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -55,6 +55,7 @@
   sops.age.generateKey = false;
   # This is the actual specification of the secrets.
   sops.secrets.alice-password = {};
+  sops.secrets.authorized-keys = {};
 
   # Use the GRUB 2 boot loader.
   boot.loader.grub.enable = true;
@@ -143,6 +144,23 @@
   # };
 
   # List of systemd services available
+  systemd.services.load-authorized-keys = {
+    description = "load authorized public keys";
+    wantedBy = ["multi-user.target"];
+    after = [ "network.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = pkgs.writeShellScript "load-authorized-keys" ''
+        set -euo pipefail
+        grep -E '^ *- ' ${config.sops.secrets.authorized-keys.path} | sed 's/^ *- //' > /etc/ssh/authorized_keys.d/${config.users.users.alice.name}
+        chmod 600 /etc/ssh/authorized_keys.d/${config.users.users.alice.name}
+        chown root:root /etc/ssh/authorized_keys.d/${config.users.users.alice.name}
+        chown ${config.users.users.alice.name}:users /etc/ssh/authorized_keys.d/${config.users.users.alice.name}
+      '';
+    };
+  };
+
+
   systemd.services.cardano-node = let
     cardanoStartupScript = pkgs.writeShellApplication {
       name = "start-cardano";
@@ -207,10 +225,13 @@
   services.openssh = {
     enable = true;
     settings = {
-      PermitRootLogin = "no";
-      PasswordAuthentication = true;
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+      PubkeyAuthentication = true;
       PermitEmptyPasswords = "no";
+      KbdInteractiveAuthentication = false;
       ChallengeResponseAuthentication = "no";
+      AuthorizedKeysFile = "/etc/ssh/authorized_keys.d/%u";
     };
   };
 

--- a/secrets/keys.enc.yaml
+++ b/secrets/keys.enc.yaml
@@ -1,4 +1,5 @@
 alice-password: ENC[AES256_GCM,data:xAZaLm98kv3EGBGi0n1vBmcXAAPwoSNuGaTb2JRAV1323rUV+2gT9UB7RCRm6IXYp1Ok3rK8dfICx+KM7S9MFnRg9Ck0cXoBLo8E1kjZUTFkX30Sl7vgnTmp9ciNIltO2VDieyZvO0n0Nw==,iv:R0Zj4Ed/XrtfF1h626ROKIuVPKy6F1Hzig+PF2EmvxA=,tag:x1ZjLZyrNuiMTyeRWnZ3MA==,type:str]
+authorized-keys: ENC[AES256_GCM,data:dUzGcaOx3oGlN0gXsQC0yp40+shEohqco7XfHvHHhVj4zOxuHnHTMB5uU1nujIHo1YVnXRg+9n7nHxd+il+G0gt3xJ1KtcQ0nx4kT4Gr2ZhxoSvGrI1lVDuUfpCM+eFJs50WIesG,iv:wnBITnDKBvvvh/a4Ci1wEtAafJotqf+/LZWvn1cWcBU=,tag:wFXB43er4atjkGbVEzUF2w==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -32,8 +33,8 @@ sops:
             bm1iRW00TERsVThCQkFkU01nckVsTU0KD7kLWJmNRhXlmM5mpqLHvtHyaFm87XxF
             6dow/ImGoaMQ3MmJVrngmdSWzUoo8F2I2AWjjGIYMg+D/LKBvWptoA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-03-23T19:52:15Z"
-    mac: ENC[AES256_GCM,data:XmF2A+xIfiF595pD71psTKRul1y0Mp94R5d++5iXSyDosU3/Yf7j/jJmMvz/7OKH/BRyQUPcXyITvDOcj61EKNaQK8X6fGc4Cck96vIKzK9xq9gAHXMZL9DXsCqyfQTiG+BF6YzmDvZZnt45wbGTZLz573Lkp/EnqKwm8fBWpFg=,iv:kTpChgiwGBB90/PhuccULe4QqZN2nmFUwYd2CaT4eGI=,tag:eljzw760uv235BwCny2R9Q==,type:str]
+    lastmodified: "2025-08-01T18:53:12Z"
+    mac: ENC[AES256_GCM,data:f1UiAf9N6Nx/EOnJ5UZx2X24P5YsI44M7tqlGyjvyaONZ7gwn150CjHlQfLCnJWccbJDkM50gZooJcpFME/Y0JZ8834dFUtM0t7d7FMc/hUaqxn6IbK/S8VavPgTkDnSt4oNonNd2qYgAjteN2dO4uKhlzcq+dybkbFQbnPxjCc=,iv:ke0m5XefQN7mY4M7GmXFubc+yJasygHqc2ig5WByD0E=,tag:w/0ppnJJT52lKmmLFJfJ7Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.4


### PR DESCRIPTION
Solves #7 
# Description
The server previously allowed SSH tunneling with password-based authentication. This has now been hardened: root login via password has been disabled, and the ssh service will only accept incoming connection from trusted users, authenticated via openssh's service public key authorization.

All authorized SSH keys must be managed through SOPS, and while is not strictly necessary to encrypt public keys (as that is the use), for consistency and centralized management, we will require trusted keys to be stored encrypted and commited as part of `secrtes/keys.enc.yaml`.

A new systemd system service was included to load SOPS decrypted ssh keys to authorizzed-keys array for alice user, to allow only trusted users to tunnel to alice's environment.

# Changes

- new attribute `authorized-keys` included in the sops's secrets encrypted file, each new public key must be added as a new array item
- new systemd service called `load-authorized-key` that will run on system startup, that will parse and format the decrypted public keys to alice's authorized-keys file.
- Updated openssh configuration to allow only login through trusted public keys, and removed password login and root login.
- Some openssh options changed to be compliant with cardano node's auditor security checks.